### PR TITLE
fix: router中间件添加忽略指定目录或文件配置

### DIFF
--- a/middleware/router/example/app.js
+++ b/middleware/router/example/app.js
@@ -13,7 +13,8 @@ app.use(router(app, {
   default_jump: true,
   suffix: '.html',
   domain: '127.0.0.1',
-  errorPath: '/error/404'
+  errorPath: '/error/404',
+  ignore: ['node_modules', 'ignored']
 }))
 
 module.exports = http.createServer(app.callback());

--- a/middleware/router/example/controller/ignored.js
+++ b/middleware/router/example/controller/ignored.js
@@ -1,0 +1,3 @@
+exports.index = function*() {
+  this.body = this.request.url;
+}

--- a/middleware/router/example/controller/path/index.js
+++ b/middleware/router/example/controller/path/index.js
@@ -1,3 +1,4 @@
+
 exports.index = function* () {
     this.body = this.request.url;
 }


### PR DESCRIPTION
router中间件添加忽略指定目录或文件配置，防止出现controller中存在node_modules依赖也会生成路由的问题。默认忽略node_modules目录，若想保留、或者禁用该功能，直接在初始化router的配置中ignore项传入[]（空数组）即可。