### PR TITLE
修改proxy中间件，使用http长连接，QPS/TPS可以提升5倍

### DIFF
--- a/middleware/proxy/index.js
+++ b/middleware/proxy/index.js
@@ -117,7 +117,8 @@ module.exports = function proxy(app, api, config, options) {
           let requestOpt = Object.assign({}, options, {
             uri: realReq.uri,
             method: realReq.method,
-            headers: headersObj
+            headers: headersObj,
+            forever: true
           }, requestData, proxyConfig.conf);
 
           // 发送请求前的钩子，可以对requestjs的参数自定义任何操作


### PR DESCRIPTION
通过云服务器微服务docker容器化部署验证。Jmeter做的压测，单pod情况下，http短链接代理请求tps大概400tps左右，使用长链接变成2000tps左右了。