### PR TITLE
修改proxy中间件，使用http长连接，QPS/TPS可以提升5倍

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ exports.demo = async function (){
  参数名 | 类型 | 默认 | 说明
  ----- | --- | ---- | ----
  `dest` | `Object` | `this.backData` | 指定接收数据的对象，默认为`this.backData`
- `conf` | `Obejct` | `{}` | this.proxy使用[requestjs](https://github.com/request/request)实现，此为传给request的重置配置（你可以在这里设置接口超时时间：`conf: { timeout: 25000 }`）
+ `conf` | `Obejct` | `{}` | this.proxy使用[requestjs](https://github.com/request/request)实现，此为传给request的重置配置（你可以在这里设置接口超时时间和http长短链接：`conf: { timeout: 25000 , keepAlive:true}`）,其中keepAlive若为true则会覆盖原请求的长短链接属性，否则对原请求没有影响
  `json` | `Object` | `{}` | 指定json格式的数据，参考：[requestjs json配置](https://github.com/request/request#requestoptions-callback)
  `form` | `Object` | `{}` | 指定application/x-www-form-urlencoded格式的数据，[requestjs form配置](https://github.com/request/request#requestoptions-callback)
  `body` | `Buffer\|String\|ReadStream` | 无 | 参考：[requestjs body配置](https://github.com/request/request#requestoptions-callback)

--- a/config/main.development.js
+++ b/config/main.development.js
@@ -22,7 +22,10 @@ module.exports = {
   // proxy配置
   proxy: {
     // 超时配置 
-    timeout: 15000
+    timeout: 15000,
+    //指定当前代理请求是否使用keepAlive形式，如果为true，将覆盖原请求header里面的keepAlive参数，否则不影响原请求header里面的keepAlive参数
+    //默认为true，实际项目中bff层一般与后端的微服务部署在内网，做成长链接后，提升性能的同时也不会造成对微服务端的资源浪费，因为一般是一个端对应一个bff，数量可控；
+    keepAlive:true
   },
 
   // controller中请求各类数据前缀和域名的键值对

--- a/config/main.production.js
+++ b/config/main.production.js
@@ -21,7 +21,10 @@ module.exports = {
   // proxy配置
   proxy: {
     // 超时配置 
-    timeout: 15000
+    timeout: 15000,
+    //指定当前代理请求是否使用keepAlive形式，如果为true，将覆盖原请求header里面的keepAlive参数，否则不影响原请求header里面的keepAlive参数
+    //默认为true，实际项目中bff层一般与后端的微服务部署在内网，做成长链接后，提升性能的同时也不会造成对微服务端的资源浪费，因为一般是一个端对应一个bff，数量可控；
+    keepAlive:true
   },
 
   // controller中请求各类数据前缀和域名的键值对

--- a/config/main.testing.js
+++ b/config/main.testing.js
@@ -22,7 +22,10 @@ module.exports = {
   // proxy配置
   proxy: {
     // 超时配置 
-    timeout: 15000
+    timeout: 15000,
+    //指定当前代理请求是否使用keepAlive形式，如果为true，将覆盖原请求header里面的keepAlive参数，否则不影响原请求header里面的keepAlive参数
+    //默认为true，实际项目中bff层一般与后端的微服务部署在内网，做成长链接后，提升性能的同时也不会造成对微服务端的资源浪费，因为一般是一个端对应一个bff，数量可控；
+    keepAlive:true
   },
 
   // controller中请求各类数据前缀和域名的键值对

--- a/middleware/proxy/index.js
+++ b/middleware/proxy/index.js
@@ -118,9 +118,9 @@ module.exports = function proxy(app, api, config, options) {
             uri: realReq.uri,
             method: realReq.method,
             headers: headersObj,
-            forever: true
+            //在request库里会变成header里的keep-alive参数
+            forever: options.keepAlive?options.keepAlive:(headersObj.connection === 'keep-alive')
           }, requestData, proxyConfig.conf);
-
           // 发送请求前的钩子，可以对requestjs的参数自定义任何操作
           proxyConfig.onBeforeRequest && proxyConfig.onBeforeRequest.call(ctx, proxyName, requestOpt)
 
@@ -190,7 +190,9 @@ module.exports = function proxy(app, api, config, options) {
           headers: headersObj,
           timeout: undefined,
           gzip: false,
-          encoding: null
+          encoding: null,
+          //在request库里会变成header里的keep-alive参数
+          forever: options.keepAlive?options.keepAlive:(headersObj.connection === 'keep-alive')
         }, requestData, config.conf);
 
         // 发送请求前的钩子，可以对requestjs的参数自定义任何操作

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gracejs",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "A Nodejs SFB(Separation of Front and Back ends) framework, build with koa 2.x",
   "main": "./src/app.js",
   "directories": {

--- a/src/app.js
+++ b/src/app.js
@@ -65,7 +65,8 @@ const vhosts = Object.keys(config.vhost).map((item) => {
     mockPath: `${config.mock.localServer}${config.mock.prefix}${appName}`
   }, {
     // request 配置
-    timeout: config.proxy.timeout // 接口超时时间
+    timeout: config.proxy.timeout, // 接口超时时间
+    keepAlive: config.proxy.keepAlive //设置proxy的keep-alive
   }));
 
   // 配置模板引擎


### PR DESCRIPTION
通过云服务器微服务docker容器化部署验证，jmeter做的压测，短链接tps大概400tps左右，使用长链接变成2000tps左右了。